### PR TITLE
feat: add not learned words models and update progress endpoint

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -67,6 +67,7 @@ func main() {
 		&models.LearnedWords{},
 		&models.LinkToken{},
 		&models.ChatHistory{},
+		&models.NotLearnedWords{},
 	)
 	if err != nil {
 		logger.Log.Fatal("Failed to auto-migrate", zap.Error(err))

--- a/backend/internal/api/v1/handlers/progress_handler.go
+++ b/backend/internal/api/v1/handlers/progress_handler.go
@@ -16,16 +16,17 @@ import (
 
 // ProgressHandler handles the progress endpoint
 type ProgressHandler struct {
-	LearnedWordRepo *postgres.LearnedWordRepository
-	WordRepo        *postgres.WordRepository
+	LearnedWordRepo    *postgres.LearnedWordRepository
+	WordRepo           *postgres.WordRepository
+	NotLearnedWordRepo *postgres.NotLearnedWordRepository
 }
 
 // ProgressRequest is a request body for updating user progress
 type ProgressRequest struct {
-	WordID          uuid.UUID `json:"word_id"`
-	LearnedAt       time.Time `json:"learned_at"`
-	ConfidenceScore int       `json:"confidence_score"`
-	CntReviewed     int       `json:"cnt_reviewed"`
+	WordID          uuid.UUID  `json:"word_id"`
+	LearnedAt       *time.Time `json:"learned_at,omitempty"`
+	ConfidenceScore *int       `json:"confidence_score,omitempty"`
+	CntReviewed     *int       `json:"cnt_reviewed,omitempty"`
 }
 
 // UpdateUserProgress godoc
@@ -65,6 +66,12 @@ func (h *ProgressHandler) UpdateUserProgress(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if len(progress) == 0 {
+		statusCode = 400
+		http.Error(w, "no progress provided", http.StatusBadRequest)
+		return
+	}
+
 	for _, p := range progress {
 		word, err := h.WordRepo.GetByID(r.Context(), p.WordID)
 		if err != nil {
@@ -82,26 +89,81 @@ func (h *ProgressHandler) UpdateUserProgress(w http.ResponseWriter, r *http.Requ
 
 		now := time.Now().UTC()
 
+		if isNotLearnedWord(p) {
+			notLearnedExists, err := h.NotLearnedWordRepo.Exists(r.Context(), userID, word.ID)
+			if err != nil {
+				statusCode = 500
+				http.Error(w, "failed to check if not learned word exists", http.StatusInternalServerError)
+				return
+			}
+
+			if !notLearnedExists {
+				nlw := &models.NotLearnedWords{
+					ID:     uuid.New(),
+					UserID: userID,
+					WordID: word.ID,
+				}
+				if err := h.NotLearnedWordRepo.Create(r.Context(), nlw); err != nil {
+					statusCode = 500
+					http.Error(w, "failed to create not learned word", http.StatusInternalServerError)
+					return
+				}
+			}
+
+			continue
+		}
+
 		if existing == nil {
 			lw := &models.LearnedWords{
-				ID:               uuid.New(),
-				UserID:           userID,
-				WordID:           word.ID,
-				LearnedAt:        p.LearnedAt,
-				LastReviewed:     now,
-				CountOfRevisions: p.CntReviewed,
-				ConfidenceScore:  p.ConfidenceScore,
+				ID:           uuid.New(),
+				UserID:       userID,
+				WordID:       word.ID,
+				LastReviewed: now,
 			}
+
+			if p.LearnedAt != nil {
+				lw.LearnedAt = *p.LearnedAt
+			} else {
+				lw.LearnedAt = now
+			}
+
+			if p.ConfidenceScore != nil {
+				lw.ConfidenceScore = *p.ConfidenceScore
+			} else {
+				lw.ConfidenceScore = 0
+			}
+
+			if p.CntReviewed != nil {
+				lw.CountOfRevisions = *p.CntReviewed
+			} else {
+				lw.CountOfRevisions = 0
+			}
+
 			if err := h.LearnedWordRepo.Create(r.Context(), lw); err != nil {
 				statusCode = 500
 				http.Error(w, "failed to create learned word", http.StatusInternalServerError)
 				return
 			}
+
+			if err := h.NotLearnedWordRepo.DeleteIfExists(r.Context(), userID, word.ID); err != nil {
+				statusCode = 500
+				http.Error(w, "failed to delete not learned word", http.StatusInternalServerError)
+				return
+			}
 		} else {
-			existing.LearnedAt = p.LearnedAt
 			existing.LastReviewed = now
-			existing.CountOfRevisions = p.CntReviewed
-			existing.ConfidenceScore = p.ConfidenceScore
+
+			if p.LearnedAt != nil {
+				existing.LearnedAt = *p.LearnedAt
+			}
+
+			if p.ConfidenceScore != nil {
+				existing.ConfidenceScore = *p.ConfidenceScore
+			}
+
+			if p.CntReviewed != nil {
+				existing.CountOfRevisions = *p.CntReviewed
+			}
 
 			if err := h.LearnedWordRepo.Update(r.Context(), existing); err != nil {
 				statusCode = 500
@@ -113,4 +175,8 @@ func (h *ProgressHandler) UpdateUserProgress(w http.ResponseWriter, r *http.Requ
 
 	// Return ok
 	w.WriteHeader(http.StatusOK)
+}
+
+func isNotLearnedWord(p ProgressRequest) bool {
+	return p.LearnedAt == nil && p.ConfidenceScore == nil && p.CntReviewed == nil
 }

--- a/backend/internal/repository/models/not_learned_word.go
+++ b/backend/internal/repository/models/not_learned_word.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"github.com/google/uuid"
+)
+
+// NotLearnedWords is a model for not learned words
+type NotLearnedWords struct {
+	ID uuid.UUID `gorm:"type:uuid;default:uuid_generate_v4();primaryKey"`
+
+	UserID uuid.UUID `gorm:"type:uuid;not null"`
+	WordID uuid.UUID `gorm:"type:uuid;not null"`
+
+	User User `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"` // user that has not learned the word
+	Word Word `gorm:"foreignKey:WordID;constraint:OnDelete:CASCADE"` // word that the user has not learned
+}
+
+func (NotLearnedWords) TableName() string {
+	return "not_learned_words"
+}

--- a/backend/internal/repository/postgres/not_learned_words_postgres.go
+++ b/backend/internal/repository/postgres/not_learned_words_postgres.go
@@ -1,0 +1,44 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fluently/go-backend/internal/repository/models"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// NotLearnedWordsRepository is a repository for not learned words
+type NotLearnedWordRepository struct {
+	db *gorm.DB
+}
+
+// NewNotLearnedWordRepository creates a new instance of NotLearnedWordRepository
+func NewNotLearnedWordRepository(db *gorm.DB) *NotLearnedWordRepository {
+	return &NotLearnedWordRepository{db: db}
+}
+
+// Exists checks if a word is not learned
+func (r *NotLearnedWordRepository) Exists(ctx context.Context, userID, wordID uuid.UUID) (bool, error) {
+	var nlw models.NotLearnedWords
+	err := r.db.WithContext(ctx).First(&nlw, "user_id = ? AND word_id = ?", userID, wordID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// Create creates a new not learned word
+func (r *NotLearnedWordRepository) Create(ctx context.Context, nlw *models.NotLearnedWords) error {
+	return r.db.WithContext(ctx).Create(nlw).Error
+}
+
+func (r *NotLearnedWordRepository) DeleteIfExists(ctx context.Context, userID, wordID uuid.UUID) error {
+	return r.db.WithContext(ctx).Where("user_id = ? AND word_id = ?", userID, wordID).
+		Delete(&models.NotLearnedWords{}).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -253,6 +253,7 @@ func InitRoutes(db *gorm.DB, r *chi.Mux) {
 	topicRepo := postgres.NewTopicRepository(db)
 	lessonRepo := postgres.NewLessonRepository(db)
 	chatHistoryRepo := postgres.NewChatHistoryRepository(db)
+	notLearnedWordRepo := postgres.NewNotLearnedWordRepository(db)
 
 	thesaurusClient := utils.NewThesaurusClient(utils.ThesaurusClientConfig{})
 	llmClient := utils.NewLLMClient(utils.LLMClientConfig{})
@@ -274,8 +275,9 @@ func InitRoutes(db *gorm.DB, r *chi.Mux) {
 		routes.RegisterPreferencesRoutes(r, &handlers.PreferenceHandler{Repo: preferenceRepo})
 		routes.RegisterPickOptionRoutes(r, &handlers.PickOptionHandler{Repo: pickOptionRepo})
 		routes.RegisterProgressRoutes(r, &handlers.ProgressHandler{
-			WordRepo:        wordRepo,
-			LearnedWordRepo: learnedWordRepo,
+			WordRepo:           wordRepo,
+			LearnedWordRepo:    learnedWordRepo,
+			NotLearnedWordRepo: notLearnedWordRepo,
 		})
 		routes.RegisterDayWordRoutes(r, &handlers.DayWordHandler{
 			WordRepo:        wordRepo,


### PR DESCRIPTION
Логика такая:
Если с клиента приходит только word id, то он будет обрабатываться, как невыученное слово. Если же все поля (те же, что и раньше) присутствуют в объекте, то он рассматривается, как выученный.
Все вставляется, если пользователь прислал, что он выучил слово, то оно добавиться в таблицу и удалиться из невыученных, если такая запись была. Ошибок с nil не будет